### PR TITLE
FlinkResultSet#close will do nothing if all results are fetched from a job

### DIFF
--- a/src/main/java/com/ververica/flink/table/jdbc/FlinkResultSet.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/FlinkResultSet.java
@@ -114,7 +114,7 @@ public class FlinkResultSet implements ResultSet {
 			return;
 		}
 
-		if (jobIdOrResultSet.isLeft()) {
+		if (jobIdOrResultSet.isLeft() && rowData.hasMoreResponse()) {
 			// no need to lock, closing while fetching new results should throw exception
 			session.cancelJob(jobIdOrResultSet.left());
 		}
@@ -1393,6 +1393,10 @@ public class FlinkResultSet implements ResultSet {
 			boolean ret = rowCount == Long.MAX_VALUE;
 			lock.readLock().unlock();
 			return ret;
+		}
+
+		boolean hasMoreResponse() {
+			return hasMoreResponse;
 		}
 
 		Row getCurrentRow() {


### PR DESCRIPTION
This PR changes the cancellation of a `FlinkResultSet`.

The JDBC driver will now do nothing if all results have been fetched from the job when cancelling a `FlinkResultSet`. This helps to improve efficiency and avoid exceptions thrown from the gateway  (in per job mode) for cancelling a job not existed anymore.