### PR TITLE
Adapt to Flink SQL gateway REST API changes

### DIFF
--- a/src/main/java/com/ververica/flink/table/jdbc/FlinkDatabaseMetaData.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/FlinkDatabaseMetaData.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.jdbc;
 import com.ververica.flink.table.gateway.rest.message.GetInfoResponseBody;
 import com.ververica.flink.table.gateway.rest.message.StatementExecuteResponseBody;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.TableSchemaUtil;
 import com.ververica.flink.table.jdbc.rest.RestUtils;
 import com.ververica.flink.table.jdbc.rest.SessionClient;
@@ -49,7 +50,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -709,8 +709,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 
 		if ("".equals(catalog) || "".equals(schemaPattern)) {
 			// every Flink database belongs to a catalog and a database
-			return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-				new GetTableResultColumnInfos().getColumnInfos(), Collections.emptyList()));
+			return FlinkResultSet.of(
+				com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+					.columns(new GetTableResultColumnInfos().getColumnInfos())
+					.data()
+					.build());
 		}
 
 		String oldCatalog = connection.getCatalog();
@@ -748,8 +752,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 				matches.add(columnInfos.process(candidate));
 			}
 		}
-		return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-			columnInfos.getColumnInfos(), matches));
+		return FlinkResultSet.of(
+			com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(columnInfos.getColumnInfos())
+				.data(matches)
+				.build());
 	}
 
 	@Override
@@ -779,10 +787,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 			maxCatalogNameLength = Math.max(maxCatalogNameLength, name.length());
 		}
 
-		return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-			Collections.singletonList(
-				ColumnInfo.create(catalogColumn, new VarCharType(true, maxCatalogNameLength))),
-			rows));
+		return FlinkResultSet.of(
+			com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(ColumnInfo.create(catalogColumn, new VarCharType(true, maxCatalogNameLength)))
+				.data(rows)
+				.build());
 	}
 
 	@Override
@@ -796,9 +806,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 			maxTypeNameLength = Math.max(maxTypeNameLength, type.length());
 		}
 
-		return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-			Collections.singletonList(ColumnInfo.create(tableTypeColumn, new VarCharType(false, maxTypeNameLength))),
-			rows));
+		return FlinkResultSet.of(
+			com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(ColumnInfo.create(tableTypeColumn, new VarCharType(false, maxTypeNameLength)))
+				.data(rows)
+				.build());
 	}
 
 	@Override
@@ -844,8 +857,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 				matches.add(columnInfos.process(candidate));
 			}
 		}
-		return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-			columnInfos.getColumnInfos(), matches));
+		return FlinkResultSet.of(
+			com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(columnInfos.getColumnInfos())
+				.data(matches)
+				.build());
 	}
 
 	@Override
@@ -886,12 +903,20 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 					matches.add(columnInfos.process(catalog, schema, table, column.getName(), pkIdx));
 				}
 			}
-			ret = FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-				columnInfos.getColumnInfos(), matches));
+			ret = FlinkResultSet.of(
+				com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+					.columns(columnInfos.getColumnInfos())
+					.data(matches)
+					.build());
 		} else {
 			// no primary keys
-			ret = FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-				columnInfos.getColumnInfos(), Collections.emptyList()));
+			ret = FlinkResultSet.of(
+				com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+					.columns(columnInfos.getColumnInfos())
+					.data()
+					.build());
 		}
 
 		connection.setCatalog(oldCatalog);
@@ -1087,8 +1112,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 
 		if ("".equals(catalog)) {
 			// every Flink database belongs to a catalog
-			return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-				new GetSchemaColumnInfos().getColumnInfos(), Collections.emptyList()));
+			return FlinkResultSet.of(
+				com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+					.columns(new GetSchemaColumnInfos().getColumnInfos())
+					.data()
+					.build());
 		}
 
 		List<SchemaResultData> candidates = new ArrayList<>();
@@ -1120,8 +1149,12 @@ public class FlinkDatabaseMetaData implements DatabaseMetaData {
 				matches.add(columnInfos.process(candidate));
 			}
 		}
-		return FlinkResultSet.of(new com.ververica.flink.table.gateway.rest.result.ResultSet(
-			columnInfos.getColumnInfos(), matches));
+		return FlinkResultSet.of(
+			com.ververica.flink.table.gateway.rest.result.ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(columnInfos.getColumnInfos())
+				.data(matches)
+				.build());
 	}
 
 	@Override

--- a/src/main/java/com/ververica/flink/table/jdbc/FlinkJdbcUtils.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/FlinkJdbcUtils.java
@@ -18,12 +18,40 @@
 
 package com.ververica.flink.table.jdbc;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
  * Util class for Flink JDBC.
  */
 public class FlinkJdbcUtils {
+
+	public static final List<String> QUERY_COMMANDS = Arrays.asList(
+		"SELECT",
+		"SHOW_MODULES",
+		"SHOW_CATALOGS",
+		"SHOW_CURRENT_CATALOG",
+		"SHOW_DATABASES",
+		"SHOW_CURRENT_DATABASE",
+		"SHOW_TABLES",
+		"SHOW_FUNCTIONS",
+		"DESCRIBE",
+		"EXPLAIN");
+
+	public static final List<String> DDL_COMMANDS = Arrays.asList(
+		"CREATE_VIEW",
+		"DROP_VIEW",
+		"CREATE_TABLE",
+		"DROP_TABLE",
+		"ALTER_TABLE",
+		"CREATE_DATABASE",
+		"DROP_DATABASE",
+		"ALTER_DATABASE",
+		"SET",
+		"RESET",
+		"USE_CATALOG",
+		"USE");
 
 	public static Pattern sqlPatternToJavaPattern(String sqlPattern) {
 		return Pattern.compile(sqlPattern

--- a/src/main/java/com/ververica/flink/table/jdbc/FlinkStatement.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/FlinkStatement.java
@@ -33,8 +33,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -43,18 +41,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Flink JDBC statement.
  */
 public class FlinkStatement implements Statement {
-
-	private static final List<String> QUERY_COMMANDS = Arrays.asList(
-		"SELECT",
-		"SHOW_MODULES",
-		"SHOW_CATALOGS",
-		"SHOW_CURRENT_CATALOG",
-		"SHOW_DATABASES",
-		"SHOW_CURRENT_DATABASE",
-		"SHOW_TABLES",
-		"SHOW_FUNCTIONS",
-		"DESCRIBE",
-		"EXPLAIN");
 
 	private final SessionClient session;
 	private final FlinkConnection connection;
@@ -523,7 +509,7 @@ public class FlinkStatement implements Statement {
 					maxRows,
 					FlinkStatement.this);
 				currentResultSet.setFetchSize(fetchSize);
-				isQuery = QUERY_COMMANDS.contains(response.getStatementTypes().get(0));
+				isQuery = FlinkJdbcUtils.QUERY_COMMANDS.contains(response.getStatementTypes().get(0));
 				return true;
 			} finally {
 				lock.writeLock().unlock();

--- a/src/main/java/com/ververica/flink/table/jdbc/resulthandler/DefaultResultHandler.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/resulthandler/DefaultResultHandler.java
@@ -20,13 +20,15 @@ package com.ververica.flink.table.jdbc.resulthandler;
 
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
+import java.sql.SQLException;
+
 /**
  * A result handler that directly forwards the {@link ResultSet} produced by the REST API.
  */
 public class DefaultResultHandler implements ResultHandler {
 
 	@Override
-	public ResultSet handleResult(ResultSet raw) {
+	public ResultSet handleResult(ResultSet raw) throws SQLException {
 		return raw;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/jdbc/resulthandler/ResultHandler.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/resulthandler/ResultHandler.java
@@ -20,10 +20,12 @@ package com.ververica.flink.table.jdbc.resulthandler;
 
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
+import java.sql.SQLException;
+
 /**
  * An interface which change {@link ResultSet}s directly returned by REST API to the form we want.
  */
 public interface ResultHandler {
 
-	ResultSet handleResult(ResultSet raw);
+	ResultSet handleResult(ResultSet raw) throws SQLException;
 }

--- a/src/main/java/com/ververica/flink/table/jdbc/resulthandler/ResultHandlerFactory.java
+++ b/src/main/java/com/ververica/flink/table/jdbc/resulthandler/ResultHandlerFactory.java
@@ -18,6 +18,8 @@
 
 package com.ververica.flink.table.jdbc.resulthandler;
 
+import com.ververica.flink.table.jdbc.FlinkJdbcUtils;
+
 /**
  * Factory to create {@link ResultHandler}s.
  */
@@ -30,6 +32,8 @@ public class ResultHandlerFactory {
 	public static ResultHandler getResultHandlerByStatementType(String statementType) {
 		if ("DESCRIBE".equals(statementType)) {
 			return new DescribeResultHandler();
+		} else if (FlinkJdbcUtils.DDL_COMMANDS.contains(statementType)) {
+			return new DdlResultHandler();
 		} else {
 			return getDefaultResultHandler();
 		}


### PR DESCRIPTION
[This pull request](https://github.com/ververica/flink-sql-gateway/pull/28) changes the REST API of Flink SQL gateway and breaks current Flink JDBC driver.

This PR adapts to the REST API changes.